### PR TITLE
emit() without merging state

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Handy dandy persistent-state pub/sub with multi, wildcard, and single-property subscriptions. **400
 bytes gzipped.**
 
-## Install 
+## Install
 ```bash
 npm i evx --save
 ```
@@ -60,6 +60,16 @@ emit('foo', { value: true })
 And all subscribers are passed the full state object:
 ```javascript
 on('foo', state => console.log(state.value)) // true
+```
+
+To emit transient data that does not get merged into the global state, pass an object as the third argument to `emit`:
+```javascript
+emit('event', null, { message: 'Hello' })
+```
+
+And access via the second argument subscribers:
+```javascript
+on('event', (state, data) => console.log(data.message)) // Hello
 ```
 
 If you need to add some state but don't want to emit any events, use `hydrate`:

--- a/index.js
+++ b/index.js
@@ -9,9 +9,9 @@ const uniq = arr => arr.reduce((a, b, i) => {
   return a.concat(b)
 }, [])
 
-const fire = (evs, events, state) => uniq(evs)
+const fire = (evs, events, state, transient) => uniq(evs)
   .reduce((fns, ev) => fns.concat(events[ev] || []), [])
-  .map(fn => fn(state))
+  .map(fn => fn(state, transient))
 
 const evx = create()
 
@@ -44,18 +44,18 @@ export function create (state = {}) {
         ev => events[ev].splice(events[ev].indexOf(fn), 1)
       )
     },
-    emit (ev, data, merge = true) {
+    emit (ev, data, transient) {
       let evs = (ev === '*' ? [] : ['*']).concat(ev)
 
       data = typeof data === 'function' ? data(state) : data
 
       if (data) {
         validate(data)
-        merge && Object.assign(state, data)
+        Object.assign(state, data)
         evs = evs.concat(Object.keys(data))
       }
 
-      fire(evs, events, merge ? state : data)
+      fire(evs, events, state, transient)
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -44,18 +44,18 @@ export function create (state = {}) {
         ev => events[ev].splice(events[ev].indexOf(fn), 1)
       )
     },
-    emit (ev, data) {
+    emit (ev, data, merge = true) {
       let evs = (ev === '*' ? [] : ['*']).concat(ev)
 
       data = typeof data === 'function' ? data(state) : data
 
       if (data) {
         validate(data)
-        Object.assign(state, data)
+        merge && Object.assign(state, data)
         evs = evs.concat(Object.keys(data))
       }
 
-      fire(evs, events, state)
+      fire(evs, events, merge ? state : data)
     }
   }
 }

--- a/test.js
+++ b/test.js
@@ -94,3 +94,12 @@ test('emit array of events', t => {
   on('bar', state => t.pass())
   emit([ 'foo', 'bar' ])
 })
+test('emit without merge', t => {
+  t.plan(2)
+  on('pubsub', data => {
+    t.true(getState().foo)
+    t.false(data.foo)
+  })
+  hydrate({ foo: true })()
+  emit('pubsub', { foo: false }, false)
+})

--- a/test.js
+++ b/test.js
@@ -94,12 +94,12 @@ test('emit array of events', t => {
   on('bar', state => t.pass())
   emit([ 'foo', 'bar' ])
 })
-test('emit without merge', t => {
+test('emit transient data', t => {
   t.plan(2)
-  on('pubsub', data => {
-    t.true(getState().foo)
-    t.false(data.foo)
+  on('pubsub', (state, data) => {
+    t.false(getState().foo)
+    t.true(data.foo)
   })
-  hydrate({ foo: true })()
-  emit('pubsub', { foo: false }, false)
+  hydrate({ foo: false })
+  emit('pubsub', null, { foo: true })
 })


### PR DESCRIPTION
Hey @estrattonbailey ... in picoapp [#19](https://github.com/estrattonbailey/picoapp/pull/19#pullrequestreview-355645626) we talked about a possible third param to `emit` that doesn't merge state and acts as a simple event emitter / pubsub interface. I realize this was mostly around my use case with picoapp, so no problem if you'd prefer not to merge this in.
Cheers!


