### PR TITLE
1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "evx",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evx",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Handy dandy persistent-state pub/sub with multi & wildcard subscriptions.",
   "source": "index.js",
   "module": "dist/evx.es.js",


### PR DESCRIPTION
picoapp is currently using **1.0.1** so not sure if this one got a minor version bump.